### PR TITLE
ghost: update to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 ctor = "0.1"
-ghost = "0.1"
+ghost = "0.1.1"
 inventory-impl = { version = "=0.1.4", path = "impl" }
 
 [workspace]


### PR DESCRIPTION
I'm not exactly sure why this is required, but it seems to be something
about the `syn` dependency requirement and/or usage.