### PR TITLE
Soundness:  Modify new before it's visible in the registry, not after.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ pub trait Collect: Sized + 'static {
 pub fn submit<T: Collect>(value: T) {
     // TODO: Avoid allocation by storing node in a static mut Option<Node<T>>
     // after existential type is stable. See comment in inventory-impl.
-    T::registry().submit(Box::leak(Box::new(Node { value, next: None })));
+    T::registry().submit(Box::new(Node { value, next: None }));
 }
 
 impl<T: 'static> Registry<T> {
@@ -151,13 +151,15 @@ impl<T: 'static> Registry<T> {
         }
     }
 
-    fn submit(&'static self, new: &'static mut Node<T>) {
+    fn submit(&'static self, new: Box<Node<T>>) {
+        let new = Box::leak(new);
+
         let mut head = self.head.load(Ordering::SeqCst);
         loop {
+            // Pointer is always null or valid &'static Node<T>.
+            new.next = unsafe { head.as_ref() };
             let prev = self.head.compare_and_swap(head, new, Ordering::SeqCst);
             if prev == head {
-                // Pointer is always null or valid &'static Node<T>.
-                new.next = unsafe { prev.as_ref() };
                 return;
             } else {
                 head = prev;


### PR DESCRIPTION
Okay, so undefined behavior would be pretty hard to trigger, but it *is* possible (I think):
* While constructor methods are being called pre-main to register with inventory's Registry...
* Have a second thread (started by another constructor method) iterate plugins.

This would be pretty boneheaded thing to do, and won't return the full list of plugins, but I've seen worse in shipped code.

https://github.com/dtolnay/inventory/blob/31b0974e6ab749967ee3506d166302c5a138221c/src/lib.rs#L154-L165

`new.next` is set *after* `new` has been inserted into the registry.
* Every `unsafe { prev.as_ref() }` on another thread possibly returns a `&Node<T>` to the `&mut Node<T>` we're modifying, which is Undefined Behavior.
* Even if it weren't UB, this would temporarilly truncate the registry to a single entry.

The first commit at least moves the `new.next` assignment *before* the CAS makes it visible in the registry.  I'm not 100% sure if this gets rid of the undefined behavior however - we technically still have a `&mut Node<T>` around.  (I've also made Registry::submit take the Box instead of the reference so it's at least easier to locally reason about soundness...)

As such, the second commit switches to keeping a `ptr::NonNull<T>` around instead of a `&'static Node<T>`.