### PR TITLE
Extend the "platform support" blurb to include all of rust-ctor's supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ that dlopen occurs.
 
 [`ctor`]: https://github.com/mmastrac/rust-ctor
 
-Platform support includes Linux, macOS and Windows. Other platforms will simply
+Platform support includes Linux, macOS, iOS, FreeBSD, Android, and Windows. Other platforms will simply
 find that no plugins have been registered. Support for other targets would need
 to be added in the `ctor` crate.
 


### PR DESCRIPTION
I can test an example on iOS if needed.