### PR TITLE
Implement Clone for iter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,6 +257,7 @@ const ITER: () = {
         }
     }
 
+    #[derive(Clone)]
     pub struct Iter<T: 'static> {
         node: Option<&'static Node<T>>,
     }


### PR DESCRIPTION
Allows cloning the iterator over plugins