### PR TITLE
Require inventory element type to be Sync

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ struct Node<T: 'static> {
 ///     inventory::iter::<T>.into_iter().count()
 /// }
 /// ```
-pub trait Collect: Sized + 'static {
+pub trait Collect: Sync + Sized + 'static {
     #[doc(hidden)]
     fn registry() -> &'static Registry<Self>;
 }

--- a/tests/ui/collect-unsized.stderr
+++ b/tests/ui/collect-unsized.stderr
@@ -13,8 +13,8 @@ note: required because it appears within the type `Unsized`
 note: required by a bound in `Collect`
    --> src/lib.rs
     |
-    | pub trait Collect: Sized + 'static {
-    |                    ^^^^^ required by this bound in `Collect`
+    | pub trait Collect: Sync + Sized + 'static {
+    |                           ^^^^^ required by this bound in `Collect`
     = note: this error originates in the macro `inventory::collect` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time

--- a/tests/ui/non-sync.rs
+++ b/tests/ui/non-sync.rs
@@ -1,0 +1,21 @@
+use std::rc::Rc;
+use std::thread;
+
+struct Thing(Rc<i32>);
+
+inventory::collect!(Thing);
+
+fn clone_all() {
+    for thing in inventory::iter::<Thing> {
+        let _ = Rc::clone(&thing.0);
+    }
+}
+
+fn main() {
+    // It would be bad if this were allowed. These threads would race on the
+    // nonatomic reference counts.
+    let thread1 = thread::spawn(clone_all);
+    let thread2 = thread::spawn(clone_all);
+    thread1.join().unwrap();
+    thread2.join().unwrap();
+}

--- a/tests/ui/non-sync.stderr
+++ b/tests/ui/non-sync.stderr
@@ -1,0 +1,18 @@
+error[E0277]: `Rc<i32>` cannot be shared between threads safely
+   --> tests/ui/non-sync.rs:6:1
+    |
+6   | inventory::collect!(Thing);
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<i32>` cannot be shared between threads safely
+    |
+    = help: within `Thing`, the trait `Sync` is not implemented for `Rc<i32>`
+note: required because it appears within the type `Thing`
+   --> tests/ui/non-sync.rs:4:8
+    |
+4   | struct Thing(Rc<i32>);
+    |        ^^^^^
+note: required by a bound in `Collect`
+   --> src/lib.rs
+    |
+    | pub trait Collect: Sync + Sized + 'static {
+    |                    ^^^^ required by this bound in `Collect`
+    = note: this error originates in the macro `inventory::collect` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
We hand out `&'static T` references onto arbitrary threads when iterating the inventory, so `T: Sync` is necessary.