### PR TITLE
Require inventory element type to be const constructed

### DIFF
--- a/examples/flags.rs
+++ b/examples/flags.rs
@@ -4,7 +4,7 @@ struct Flag {
 }
 
 impl Flag {
-    fn new(short: char, name: &'static str) -> Self {
+    const fn new(short: char, name: &'static str) -> Self {
         Flag { short, name }
     }
 }

--- a/tests/ui/collect-unsized.stderr
+++ b/tests/ui/collect-unsized.stderr
@@ -16,22 +16,3 @@ note: required by a bound in `Collect`
     | pub trait Collect: Sync + Sized + 'static {
     |                           ^^^^^ required by this bound in `Collect`
     = note: this error originates in the macro `inventory::collect` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the size for values of type `str` cannot be known at compilation time
-   --> tests/ui/collect-unsized.rs:3:1
-    |
-3   | inventory::collect!(Unsized);
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
-    |
-    = help: within `Unsized`, the trait `Sized` is not implemented for `str`
-note: required because it appears within the type `Unsized`
-   --> tests/ui/collect-unsized.rs:1:12
-    |
-1   | pub struct Unsized(str);
-    |            ^^^^^^^
-note: required by a bound in `Registry`
-   --> src/lib.rs
-    |
-    | pub struct Registry<T: 'static> {
-    |                     ^ required by this bound in `Registry`
-    = note: this error originates in the macro `inventory::collect` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/submit-unrecognized.stderr
+++ b/tests/ui/submit-unrecognized.stderr
@@ -1,12 +1,9 @@
 error[E0277]: the trait bound `Thing: Collect` is not satisfied
-   --> tests/ui/submit-unrecognized.rs:3:1
-    |
-3   | inventory::submit!(Thing);
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Collect` is not implemented for `Thing`
-    |
-note: required by a bound in `submit`
-   --> src/lib.rs
-    |
-    | pub fn submit<T: Collect>(value: T) {
-    |                  ^^^^^^^ required by this bound in `submit`
-    = note: this error originates in the macro `inventory::submit` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> tests/ui/submit-unrecognized.rs:3:1
+  |
+3 | inventory::submit!(Thing);
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Collect` is not implemented for `Thing`
+  |
+  = note: required because of the requirements on the impl of `ErasedNode` for `Thing`
+  = note: required for the cast to the object type `dyn ErasedNode`
+  = note: this error originates in the macro `inventory::submit` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
The Rust standard library is not yet properly initialized during life before main, so sticking things like the following in there is problematic and must not be allowed.

```rust
inventory::submit!({
    std::println!("???");
    std::thread::spawn(...);
    Thing {}
});
```