### PR TITLE
Update ctor dependency to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/dtolnay/inventory"
 rust-version = "1.62"
 
 [dependencies]
-ctor = "0.1"
+ctor = "0.2"
 ghost = "0.1.4"
 
 [dev-dependencies]


### PR DESCRIPTION
Not sure why this was made 0.2.0. I don't see any relevant API change relative to ctor 0.1.26.