### PR TITLE
Add a way to use `#[used(linker)]`

### DIFF
--- a/tests/ui/outer-attr.rs
+++ b/tests/ui/outer-attr.rs
@@ -1,0 +1,10 @@
+struct Thing;
+
+inventory::collect!(Thing);
+
+inventory::submit! {
+    #[used(linker)]
+    Thing
+}
+
+fn main() {}

--- a/tests/ui/outer-attr.stderr
+++ b/tests/ui/outer-attr.stderr
@@ -1,0 +1,5 @@
+error: attribute must be applied to a `static` variable
+ --> tests/ui/outer-attr.rs:6:5
+  |
+6 |     #[used(linker)]
+  |     ^^^^^^^^^^^^^^^

--- a/tests/ui/submit-unrecognized.stderr
+++ b/tests/ui/submit-unrecognized.stderr
@@ -6,4 +6,4 @@ error[E0277]: the trait bound `Thing: Collect` is not satisfied
   |
   = note: required for `Thing` to implement `ErasedNode`
   = note: required for the cast from `&Thing` to `&'static (dyn ErasedNode + 'static)`
-  = note: this error originates in the macro `inventory::submit` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::__do_submit` which comes from the expansion of the macro `inventory::submit` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/used-linker.rs
+++ b/tests/ui/used-linker.rs
@@ -1,0 +1,10 @@
+struct Thing;
+
+inventory::collect!(Thing);
+
+inventory::submit! {
+    #![used(linker)]
+    Thing
+}
+
+fn main() {}

--- a/tests/ui/used-linker.stderr
+++ b/tests/ui/used-linker.stderr
@@ -1,0 +1,8 @@
+error[E0658]: `#[used(linker)]` is currently unstable
+ --> tests/ui/used-linker.rs:6:5
+  |
+6 |     #![used(linker)]
+  |     ^^^^^^^^^^^^^^^^
+  |
+  = note: see issue #93798 <https://github.com/rust-lang/rust/issues/93798> for more information
+  = help: add `#![feature(used_with_arg)]` to the crate attributes to enable


### PR DESCRIPTION
```rust
inventory::submit! {
    #![used(linker)]
    Foo::new(...)
}
```