### PR TITLE
Work around ICE in rustc: the naive layout isn't refined by the actual layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           toolchain: ${{matrix.rust}}
       - name: Enable type layout randomization
         run: echo RUSTFLAGS=${RUSTFLAGS}\ -Zrandomize-layout >> $GITHUB_ENV
-        if: startsWith(matrix.rust, 'nightly')
+        if: startsWith(matrix.rust, 'nightly') && false # FIXME https://github.com/rust-lang/rust/issues/113941
       - run: cargo test
 
   clippy:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,9 @@ document_iter! {
 mod void_iter {
     enum Void {}
 
-    pub struct Iter<T>([*const T; 0], Void);
+    // https://github.com/rust-lang/rust/issues/113941
+    const WORK_AROUND_RUST_ISSUE_113941: usize = 1;
+    pub struct Iter<T>([*const T; WORK_AROUND_RUST_ISSUE_113941], Void);
 
     unsafe impl<T> Send for Iter<T> {}
     unsafe impl<T> Sync for Iter<T> {}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,6 +4,7 @@ struct Thing(usize);
 
 #[test]
 fn test_iter() {
-    assert_eq!(0, mem::size_of::<inventory::iter<Thing>>());
-    assert_eq!(1, mem::align_of::<inventory::iter<Thing>>());
+    // https://github.com/rust-lang/rust/issues/113941
+    assert_eq!(16, mem::size_of::<inventory::iter<Thing>>()); // FIXME
+    assert_eq!(8, mem::align_of::<inventory::iter<Thing>>()); // FIXME
 }


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/113941