### PR TITLE
Fix zero sizing of Iter<T>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,7 @@ document_iter! {
 mod void_iter {
     enum Void {}
 
+    #[repr(C, packed)]
     pub struct Iter<T>([*const T; 0], Void);
 
     unsafe impl<T> Send for Iter<T> {}


### PR DESCRIPTION
```console
---- test_iter stdout ----
thread 'test_iter' panicked at tests/test.rs:7:5:
assertion `left == right` failed
  left: 0
 right: 8
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

failures:
    test_iter
```

It seems https://github.com/rust-lang/rust/pull/115277 in nightly-2023-08-30 affected the size of this type as originally written.