### PR TITLE
Eliminate `cfg(doc)`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,13 +236,6 @@ macro_rules! document_iter {
     };
 }
 
-#[cfg(doc)]
-document_iter! {
-    #[allow(non_camel_case_types)]
-    pub struct iter<T>;
-}
-
-#[cfg(not(doc))]
 mod void_iter {
     enum Void {}
 
@@ -253,12 +246,10 @@ mod void_iter {
     unsafe impl<T> Sync for Iter<T> {}
 }
 
-#[cfg(not(doc))]
 mod value_iter {
     pub use crate::iter::iter;
 }
 
-#[cfg(not(doc))]
 document_iter! {
     // Based on https://github.com/dtolnay/ghost
     #[allow(non_camel_case_types)]
@@ -268,7 +259,6 @@ document_iter! {
     }
 }
 
-#[cfg(not(doc))]
 #[doc(hidden)]
 pub use crate::value_iter::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,42 +199,39 @@ impl Registry {
     }
 }
 
-macro_rules! document_iter {
-    ($iter:item) => {
-        /// An iterator over plugins registered of a given type.
-        ///
-        /// The value `inventory::iter::<T>` is an iterator with element type `&'static
-        /// T`.
-        ///
-        /// There is no guarantee about the order that plugins of the same type are
-        /// visited by the iterator. They may be visited in any order.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// # struct Flag {
-        /// #     short: char,
-        /// #     name: &'static str,
-        /// # }
-        /// #
-        /// # inventory::collect!(Flag);
-        /// #
-        /// # const IGNORE: &str = stringify! {
-        /// use my_flags::Flag;
-        /// # };
-        ///
-        /// fn main() {
-        ///     for flag in inventory::iter::<Flag> {
-        ///         println!("-{}, --{}", flag.short, flag.name);
-        ///     }
-        /// }
-        /// ```
-        ///
-        /// Refer to the [crate level documentation](index.html) for a complete example
-        /// of instantiating a plugin registry and submitting plugins.
-        $iter
-    };
-}
+/// An iterator over plugins registered of a given type.
+///
+/// The value `inventory::iter::<T>` is an iterator with element type `&'static
+/// T`.
+///
+/// There is no guarantee about the order that plugins of the same type are
+/// visited by the iterator. They may be visited in any order.
+///
+/// # Examples
+///
+/// ```
+/// # struct Flag {
+/// #     short: char,
+/// #     name: &'static str,
+/// # }
+/// #
+/// # inventory::collect!(Flag);
+/// #
+/// # const IGNORE: &str = stringify! {
+/// use my_flags::Flag;
+/// # };
+///
+/// fn main() {
+///     for flag in inventory::iter::<Flag> {
+///         println!("-{}, --{}", flag.short, flag.name);
+///     }
+/// }
+/// ```
+///
+/// Refer to the [crate level documentation](index.html) for a complete example
+/// of instantiating a plugin registry and submitting plugins.
+#[allow(non_camel_case_types)]
+pub type iter<T> = private::iter<T>;
 
 mod void_iter {
     enum Void {}
@@ -247,20 +244,24 @@ mod void_iter {
 }
 
 mod value_iter {
-    pub use crate::iter::iter;
+    #[doc(hidden)]
+    pub use crate::private::iter::iter;
 }
 
-document_iter! {
+mod private {
     // Based on https://github.com/dtolnay/ghost
     #[allow(non_camel_case_types)]
     pub enum iter<T> {
-        __Phantom(void_iter::Iter<T>),
+        __Phantom(crate::void_iter::Iter<T>),
         iter,
     }
+
+    #[doc(hidden)]
+    pub use crate::value_iter::*;
 }
 
 #[doc(hidden)]
-pub use crate::value_iter::*;
+pub use crate::private::*;
 
 const ITER: () = {
     fn into_iter<T: Collect>() -> Iter<T> {


### PR DESCRIPTION
See https://github.com/dtolnay/ghost/pull/20.

```console
error[E0392]: parameter `T` is never used
   --> src/lib.rs:242:21
    |
242 |     pub struct iter<T>;
    |                     ^ unused parameter
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `core::marker::PhantomData`
    = help: if you intended `T` to be a const parameter, use `const T: usize` instead
```