### PR TITLE
Add feature to force .init_array and .text.startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,17 @@ life-before-main, see the [`linkme`] crate.
 
 [`linkme`]: https://github.com/dtolnay/linkme
 
+### Unsupported OS support
+
+Some "exotic" platforms might support constructors out of the box, but might not
+be identified as "supported OS". You can still **"try"** to make this works by
+forcing constructors with the following feature `inventory_force_init_array`.
+You will have to define this feature in your own project as Inventory injects
+code with the `submit!` macro, forcing you to declare the feature yourself.
+
+You can do the same to force the constructors to be defined in the .text.startup
+section by using `inventory_force_text_startup`.
+
 <br>
 
 #### License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,7 +423,14 @@ macro_rules! __do_submit {
                 next: $crate::core::cell::UnsafeCell::new($crate::core::option::Option::None),
             };
 
-            #[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".text.startup")]
+            #[cfg_attr(
+                any(
+                    target_os = "linux",
+                    target_os = "android",
+                    feature = "inventory_force_text_startup",
+                ),
+                link_section = ".text.startup"
+            )]
             unsafe extern "C" fn __ctor() {
                 unsafe { $crate::ErasedNode::submit(__INVENTORY.value, &__INVENTORY) }
             }
@@ -445,6 +452,7 @@ macro_rules! __do_submit {
                     target_os = "illumos",
                     target_os = "netbsd",
                     target_os = "openbsd",
+                    feature = "inventory_force_init_array",
                 ),
                 link_section = ".init_array",
             )]


### PR DESCRIPTION
Sometime target_os is not defined in our list but .text.startup and .init_array works as expected.
We should let the user force the feature if so.

Since we use macro_rule, the features must be defined by the user package