### PR TITLE
Support `target_os = "none"`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,6 +450,7 @@ macro_rules! __do_submit {
                     target_os = "illumos",
                     target_os = "netbsd",
                     target_os = "openbsd",
+                    target_os = "none",
                 ),
                 link_section = ".init_array",
             )]


### PR DESCRIPTION
Alternative take on https://github.com/dtolnay/inventory/pull/66.

Adds a feature called `force-init-array-section` to force `__do_submit!` to assign `static __CTOR` to the `.init_array` section, regardless of the platform. This enables support for arbitrary platforms that support `.init_array` constructors.

Unlike https://github.com/dtolnay/inventory/pull/66, this is an intrinsic feature of the `inventory` crate.