### PR TITLE
0.1.11 tvOS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 rust-version = "1.31"
 
 [dependencies]
-ctor = { git = "https://github.com/ErikEverson/rust-ctor.git", rev = "7d5922f89550d14e5148736636d776124fe2f51c" }
+ctor = "0.2.7"
 ghost = "0.1.1"
 inventory-impl = { version = "=0.1.11", path = "impl" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 rust-version = "1.31"
 
 [dependencies]
-ctor = "0.1"
+ctor = { git = "https://github.com/ErikEverson/rust-ctor.git", rev = "7d5922f89550d14e5148736636d776124fe2f51c" }
 ghost = "0.1.1"
 inventory-impl = { version = "=0.1.11", path = "impl" }
 


### PR DESCRIPTION
- Targeting master as there is not branch for tag 0.1.11 and can't PR a tag
- Adding tvOS support to 0.1.11 version by bumping CTOR version to 0.2.7.

How was this tested:
- Tested from https://github.com/getditto/safer_ffi using inventory 0.1.11.
    - cargo +nightly build -Z build-std --lib --target aarch64-apple-tvos
- Testing in Inventory 0.1.11 
    - cargo +nightly build -Z build-std --lib --target aarch64-apple-tvos
    - cargo test [nightly, stable, beta, 1.31.0]
    
@phatblat for eventual visionOS support.