### PR TITLE
Use `.init_array` section on wasi and emscripten

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -451,6 +451,8 @@ macro_rules! __do_submit {
                     target_os = "illumos",
                     target_os = "netbsd",
                     target_os = "openbsd",
+                    target_os = "emscripten",
+                    target_os = "wasi",
                     target_os = "none",
                 ),
                 link_section = ".init_array",


### PR DESCRIPTION
Thanks to some [recent work](https://github.com/llvm/llvm-project/pull/119533) on how LLVM handles `.init_array` for WebAssembly targets, the `emscripten` and `wasi` OSs should now work as of LLVM 19.1.6 and Rust `nightly-2024-12-19`.

More information and an example is in the comment and thread at https://github.com/dtolnay/inventory/issues/71#issuecomment-2553150709.