### PR TITLE
Make Wasm link section conditional on compiler version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/inventory"
 rust-version = "1.62"
 
+[target.'cfg(any(target_os = "emscripten", target_os = "wasi"))'.dependencies]
+rustversion = "1.0"
+
 [dev-dependencies]
 rustversion = "1.0"
 trybuild = { version = "1.0.89", features = ["diff"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,6 +418,14 @@ macro_rules! submit {
 }
 
 // Not public API.
+#[cfg(any(target_os = "emscripten", target_os = "wasi"))]
+#[doc(hidden)]
+pub mod __private {
+    #[doc(hidden)]
+    pub use rustversion::attr;
+}
+
+// Not public API.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __do_submit {
@@ -451,11 +459,16 @@ macro_rules! __do_submit {
                     target_os = "illumos",
                     target_os = "netbsd",
                     target_os = "openbsd",
-                    target_os = "emscripten",
-                    target_os = "wasi",
                     target_os = "none",
                 ),
                 link_section = ".init_array",
+            )]
+            #[cfg_attr(
+                any(target_os = "emscripten", target_os = "wasi"),
+                $crate::__private::attr(
+                    any(all(stable, since(1.85)), since(2024-12-18)),
+                    link_section = ".init_array",
+                ),
             )]
             #[cfg_attr(
                 any(target_os = "macos", target_os = "ios"),


### PR DESCRIPTION
In order to avoid triggering a link error where there didn't used to be one. #74 causes rust-lld errors like this in compilers older than nightly-2024-12-19:

```console
error: linking with `wasm-component-ld` failed: exit status: 1
  |
  = note: "wasm-component-ld" "-flavor" "wasm" "--export" "__main_void" "--export" "cabi_realloc" "-z" "stack-size=1048576" "--stack-first" "--allow-undefined" "--no-demangle" {...} "-l" "c" "-L" ".rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-wasip2/lib/self-contained" "-o" "target/wasm32-wasip2/debug/deps/repro-2c59c9d65bdd9014.wasm" "--gc-sections" "-O0"
  = note: rust-lld: error: target/wasm32-wasip2/debug/deps/repro-2c59c9d65bdd9014.am9l6ff8xuqu3stbvow8o8tiz.rcgu.o: invalid data symbol offset: `_ZN5repro1_6__CTOR17h2780dd13c1356084E` (offset: 4 segment size: 1)
          error: failed to invoke LLD: exit status: 1
```