### PR TITLE
Fix illumos .init_array section creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,34 @@ life-before-main, see the [`linkme`] crate.
 
 <br>
 
+### Illumos Compatibility
+
+This crate requires Rust nightly when compiling for illumos targets due to its
+dependency on the unstable `used_with_arg` feature.
+
+To use this crate on illumos, you must enable the required feature in all 
+crates that use `inventory`. Add one of the following to the top of your crate's
+entry point (typically `main.rs` or `lib.rs`):
+
+**For illumos-only applications:**
+```rust
+#![feature(used_with_arg)]
+```
+
+**For cross-platform applications:**
+```rust
+#[cfg_attr(target_os = "illumos", feature(used_with_arg))]
+```
+
+The conditional approach allows your application to compile on stable Rust for
+other platforms while only requiring nightly on illumos.
+
+This is because the illumos linker does not properly handle the multiple
+`.init_array` sections created when using `#[used]`. You can find more
+information [here](https://system-illumination.org/01-rustler.html).
+
+<br>
+
 #### License
 
 <sup>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,7 +563,8 @@ macro_rules! __do_submit {
 
     ({ $($value:tt)* } { $($dup:tt)* }) => {
         $crate::__do_submit! {
-            used={ #[used] }
+            used={ #[cfg_attr(target_os = "illumos", used(compiler))]
+                   #[cfg_attr(not(target_os = "illumos"), used)] }
             $($value)*
         }
     };


### PR DESCRIPTION
Hey there! I've been debugging this issue for the some days and did a write up with more details that I link
to at the end of the PR.

I've tried to keep the disturbance to a minimum but sadly it seems that we need an unstable feature, and thus nightly
for illumos. I don't have a lot of rust experience so I may have done something wrong but I think all other platforms
should still work under stable.

Under illumos the #[used] tag emits an `llvm.used` flag, this gets converted into a SHF_SUNW_NODISCARD Solaris flag that illumos doesn't understand. The linker then doesn't merge the two .init_array sections since they have different flags.

Because we end up with two .init_array sections and the one pointed by default by DT_INIT_ARRAY is the first ""incorrect"" one, inventory doesn't work under illumos when using the illumos linker (the default).

This patch changes the default behaviour under illumos to not using #[used].

Some references:
 + https://reviews.llvm.org/D107955#:~:text=One,them 
 + https://reviews.llvm.org/D97448
 + My own writeup of investigating this issue: https://system-illumination.org/01-rustler.html