### PR TITLE
Add support for VxWorks targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -544,6 +544,7 @@ macro_rules! __do_submit {
                         target_os = "netbsd",
                         target_os = "nto",
                         target_os = "openbsd",
+                        target_os = "vxworks",
                         target_os = "none",
                     )
                 ),


### PR DESCRIPTION
Adds [VxWorks](https://doc.rust-lang.org/rustc/platform-support/vxworks.html) to the list of targets that utilize the ELF link section.

Functionality has been verified on VxWorks 25.09.